### PR TITLE
Some little changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ Video downloader in python with pytube module (Supports Playlist Links)
 Use the package manager [pip](https://pip.pypa.io/en/stable/) to install pytube and PyQt5.
 
 ```bash
-pip install pytube
-pip install PyQt5
+pip3 install -r requirements.txt
 ```
 ## Usage
 1-) Open the app:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyQt5
+pytube

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python youtubeApp.py
+python3 youtubeApp.py


### PR DESCRIPTION
requirements.txt added and readme updated about using requirements.txt for installation.
start.sh changes as `python3 youtubeApp.py` because on macOS and most Linux distros, python means Python 2 and you have to use python3 to specify using Python 3.